### PR TITLE
Adding virtualenv as openstack ops required package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+openstack_ops_requires_pip_packages:
+  - "virtualenv"
+
 openstack_ops_pip_dependencies:
   - "python-openstackclient"
   - "shade"

--- a/tasks/install_dependencies.yml
+++ b/tasks/install_dependencies.yml
@@ -13,12 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Create venv base directory
+  file:
+    dest: "{{ openstack_ops_venv |dirname }}"
+    owner: "root"
+    group: "root"
+    mode: "755"
+    state: "directory"
+  when: openstack_ops_pip_venv_enabled |bool
+  tags:
+   - always
+
+
+- name: Install requires pip packages
+  pip:
+    name: "{{ openstack_ops_requires_pip_packages | join(' ') }}"
+    state: latest
+    extra_args: >-
+      {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
+      {{ pip_install_options | default('') }}
+  register: install_packages
+  until: install_packages|success
+  retries: 5
+  delay: 2
+  tags:
+    - always
+
 - name: Install pip dependencies
   pip:
     name: "{{ item }}"
     extra_args: "{{ pip_install_options|default('') }}"
     virtualenv: "{{ openstack_ops_venv }}"
-  with_items: openstack_ops_pip_dependencies
+  with_items: "{{ openstack_ops_pip_dependencies }}"
   when: openstack_ops_pip_dependencies is defined
   register: pip_install
   until: pip_install|success


### PR DESCRIPTION
This will round up the shade installation in a support venv and include necessary packages to even build the venv