### PR TITLE
Removing shade versio caps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-shade<=1.13.0
-os-client-config<=1.21.0
+shade
+os-client-config
+python-openstackclient

--- a/tasks/create_default_nova_flavors.yml
+++ b/tasks/create_default_nova_flavors.yml
@@ -16,23 +16,17 @@
 - name: Add default Nova flavors
   environment:
     PYTHONHOME: "{{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}"
-  os_nova_flavor:
-    name: "{{ item.name }}"
-    vcpus: "{{ item.vcpus }}"
-    state: present
-    endpoint_type: "internal"
-    disk: "{{ item.disk }}"
-    ram: "{{ item.ram }}"
-    auth:
-      auth_url: "{{ keystone_service_internalurl }}"
-      username: "admin"
-      password: "{{ keystone_auth_admin_password }}"
-      project_name: "admin"
-      domain_name: "Default"
-    validate_certs: false
+  shell: |
+    openstack --os-cloud default flavor create --ram {{ item.RAM }} --disk {{ item.Disk }} --vcpus {{ item.VCPUs }} --public {{ item.Name }}
+  register: flavor_create
+  failed_when:
+    - flavor_create.stderr.find('already exists') == -1
+    - flavor_create.rc != 0
+  changed_when:
+    - flavor_create.rc == 0
   with_items:
-    - { name: 'm1.tiny', vcpus: '1', disk: '1', ram: '512' }
-    - { name: 'm1.small', vcpus: '1', disk: 20, ram: '2048' }
-    - { name: 'm1.medium', vcpus: '2', disk: '40', ram: '4096' }
-    - { name: 'm1.large', vcpus: '4', disk: '80', ram: '8192' }
-    - { name: 'm1.xlarge', vcpus: '8', disk: '160', ram: '16384' }
+    - { Name: 'm1.tiny', VCPUs: '1', Disk: '1', RAM: '512' }
+    - { Name: 'm1.small', VCPUs: '1', Disk: 20, RAM: '2048' }
+    - { Name: 'm1.medium', VCPUs: '2', Disk: '40', RAM: '4096' }
+    - { Name: 'm1.large', VCPUs: '4', Disk: '80', RAM: '8192' }
+    - { Name: 'm1.xlarge', VCPUs: '8', Disk: '160', RAM: '16384' }


### PR DESCRIPTION
The current openstack global requirements are capping libraries needed for shade
Removing these caps will eventually include shade in later builds, until then
we are favoring the openstack client.

(cherry picked from commit f1d6d18db373a3ac8215f1cff7c62add82d5a334)