### PR TITLE
Replace ansible_ssh_host with ansible_host

### DIFF
--- a/tasks/distribute_auth_key.yml
+++ b/tasks/distribute_auth_key.yml
@@ -18,7 +18,7 @@
     name: "{{ item.name }}"
     file_path: "{{ item.src }}"
     state: "present"
-    server: "{{ hostvars[groups['memcached'][0]]['ansible_ssh_host'] }}:11211"
+    server: "{{ hostvars[groups['memcached'][0]]['ansible_host'] }}:11211"
     encrypt_string: "{{ memcached_encryption_key }}"
     expires: 86400
   with_items:

--- a/tasks/retrieve_auth_key.yml
+++ b/tasks/retrieve_auth_key.yml
@@ -33,7 +33,7 @@
     state: "retrieve"
     file_mode: "{{ item.file_mode }}"
     dir_mode: "{{ item.dir_mode }}"
-    server: "{{ hostvars[groups['memcached'][0]]['ansible_ssh_host'] }}:11211"
+    server: "{{ hostvars[groups['memcached'][0]]['ansible_host'] }}:11211"
     encrypt_string: "{{ memcached_encryption_key }}"
   with_items:
     - src: "/root/.ssh/rpc_support"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint>=2.7.0,<3.0.0
+ansible-lint>=2.7.0,<3.4.13
 flake8==2.2.4
 hacking>=0.10.0,<0.11
 pep8==1.5.7

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ whitelist_externals =
     sed
 deps =
     -rtest-requirements.txt
-    ansible{env:ANSIBLE_VERSION:==2.1.0}
+    ansible{env:ANSIBLE_VERSION:==2.2.2}
 
 setenv =
     ANSIBLE_ACTION_PLUGINS = {homedir}/.ansible/roles/plugins/action


### PR DESCRIPTION
In preperation for Ansible 2.2.2, which removes the use of
``ansible_ssh_host``, all occurrences of ``ansible_ssh_host``
in this role have been replaced with ``ansible_host``.

This commit also makes changes in tox.ini and test-requirements.txt
to set the appropriate versions for ansible and ansible-lint

Connects https://github.com/rcbops/u-suk-dev/issues/1601