### PR TITLE
Use correct holland vars in config template

### DIFF
--- a/templates/holland.conf.j2
+++ b/templates/holland.conf.j2
@@ -17,7 +17,7 @@ umask = 0007
 
 # Define a path for holland and its spawned processes
 
-path = {% if holland_venv_enabled | bool %}{{holland_venv_bin}}:{% endif %}/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+path = {% if ops_holland_venv_enabled | bool %}{{ ops_holland_venv_bin }}:{% endif %}/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 
 [logging]
 ## where to write the log


### PR DESCRIPTION
Currently the role execution fails with an undefined
variable. This fixes that.

Solves https://github.com/rsoprivatecloud/openstack-ops/issues/19