### PR TITLE
Adding HP firmware update automation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ ops_apt_util_packages:
   - sudo
   - tcpdump
   - vim
+  - screen
 
 ops_apt_host_packages:
   - linux-crashdump
@@ -52,6 +53,19 @@ ops_hwraid_apt_keys:
 ops_hwraid_apt_packages:
   - megacli
   - lsiutil
+
+
+ops_update_hp_firmware: False
+
+ops_hp_tools_apt_repo_url: "http://downloads.linux.hpe.com/SDR/repo/mcp/ubuntu/"
+ops_hp_tools_apt_repo_keys:
+  - { url: "https://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub", state: "present" }
+ops_hp_tools_apt_firmware_packages:
+  - rpm2cpio
+  - dmidecode
+  - ethtool
+  - hpssacli
+  - hponcfg
 
 
 ops_holland_venv_enabled: True

--- a/files/update_hp_firmware.py
+++ b/files/update_hp_firmware.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python
+#
+#
+#
+
+import requests
+import os
+import sys
+import re
+import json
+import argparse
+import subprocess
+import datetime as dt
+from subprocess import PIPE
+
+VERSION = '2017-05-31'
+
+checkPrereqs    = ["dmidecode", "ethtool", "hpssacli", "hponcfg"]
+installPrereqs  = ["rpm2cpio"]
+
+baseUrl = "http://aaronsegura.com/hpfw/"
+workDir = "%s/%s-%s" % (os.environ["HOME"], "hpfw-upgrade", dt.datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))
+ret     = 0
+
+parser  = argparse.ArgumentParser(description="HP Firmware Upgrade Utility v%s" % VERSION)
+parser.add_argument("-f", help="Do Flash (otherwise, just dry run)", dest="flash", action="store_const", const=True, default=False)
+parser.add_argument("-i", help="Install missing utilities and run check, no Flash", dest="install", action="store_const", const=True, default=False)
+parser.add_argument("-r", help="Generate JSON report of current versions", dest="report", action="store_const", const=True, default=False)
+parser.add_argument("--NIC", help="Flash NIC firmware", dest="do", action="append_const", const="NIC")
+parser.add_argument("--SYS", help="Flash System BIOS", dest="do", action="append_const", const="SYSTEM")
+parser.add_argument("--RAID", help="Flash RAID Controller", dest="do", action="append_const", const="RAID")
+parser.add_argument("--ILO", help="Flash ILO Controller", dest="do", action="append_const", const="ILO")
+
+args = parser.parse_args()
+
+if args.do == None:
+  args.do = ["NIC", "SYSTEM", "RAID", "ILO"]
+
+if not args.flash and not args.install and not args.report:
+  print ""
+  print "*********************************************"
+  print "PERFORMING DRY RUN.  NO CHANGES WILL BE DONE."
+  print "*********************************************"
+  print ""
+elif args.install:
+  print ""
+  print "*********************************************"
+  print "     INSTALLING REQUIRED UTILITIES ONLY."
+  print "*********************************************"
+  print ""
+
+if not os.path.exists(workDir) and args.flash:
+  try:
+    os.mkdir(workDir)
+  except OSError, err:
+    print "ERROR: %s" % err.message
+    if 'exists' in err.message:
+      pass
+    else:
+      print "Unable to create working directory %s: %s" % (workDir, err.message)
+      exit(255)
+
+if args.flash:
+  try:
+    os.chdir(workDir)
+  except:
+    print "Something went horribly wrong.  Aborting."
+    exit(254)
+
+firmwares = {}
+firmwares["ProLiant DL380 Gen9"] = {
+  "NIC": {
+    "check" : "ethtool -i em1 | grep firmware | cut -d:  -f2- | tr -d ' '",
+    "ver"   : "5719-v1.46NCSIv1.3.16.0",
+    "fwpkg" : "hp-firmware-nic-broadcom-2.17.6-1.1.x86_64.rpm",
+    "md5"   : "d300a2a95c1e4617bd4a07eede322511",
+    "inp"   : "\n",
+    "ret"   : 1
+  },
+  "SYSTEM": {
+    "check" : "hpasmcli -s \"show server\" | grep ROM | cut -d: -f2- | tr -d ' '",
+    "ver"   : "02/17/2017",
+    "fwpkg" : "hp-firmware-system-p89-2.40_2017_02_17-2.1.i386.rpm",
+    "md5"   : "4506ed3576c05989070fbe75bb58d65e",
+    "inp"   : "y\nn\n",
+    "ret"   : 1
+  },
+  "ILO": {
+    "check" : "hponcfg -h | egrep Firmware | cut -d\  -f4",
+    "ver"   : "2.50",
+    "fwpkg" : "hp-firmware-ilo4-2.50-1.1.i386.rpm",
+    "md5"   : "2141f1ff4f7a3ea637fd6e500add816d",
+    "inp"   : "y\n",
+    "ret"   : 0
+  },
+  "RAID": {
+    "check" : "hpssacli controller all show config detail | grep -i firmware\ version | cut -d: -f2 | tr -d ' '| head -1",
+    "ver"   : "5.04",
+    "fwpkg" : "hp-firmware-smartarray-ea3138d8e8-5.04-1.1.x86_64.rpm",
+    "md5"   : "a2fd504e1f77333f38ba5bbdbdeec36a",
+    "inp"   : "A\n",
+    "ret"   : 1
+  }
+}
+
+# Check for pre-requisite packages necessary to determine versions
+if not args.report:
+  print "Checking for intial pre-requisites..."
+for i in checkPrereqs:
+  p = subprocess.Popen(['/usr/bin/env', 'which', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+  p.communicate()
+  if p.returncode > 0:
+    if not args.flash and not args.install:
+      sys.stdout.write("Unable to find %s, but performing DRY RUN, so will not be installed.  Stopping.\n" % i)
+      exit(2)
+    else:
+      sys.stdout.write("Unable to find %s.  Installing..." % i)
+      sys.stdout.flush()
+      p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+      p.communicate()
+      if p.returncode > 0:
+        print "Failed.  Do the needful." 
+        exit(1)
+      else:
+        print "Success!"
+
+
+# Verify supported hardware
+p = subprocess.Popen(['/usr/bin/env', 'dmidecode', '-s', 'system-product-name'], stdout=PIPE)
+(sysType, stdErr) = p.communicate()
+
+sysType = sysType.strip()
+if sysType not in firmwares:
+  print "Hardware version \"%s\" not supported." % sysType
+  exit(2)
+elif not args.report:
+  print "Verified supported hardware: %s" % sysType
+
+# Check for additional pre-requisite packages necessary to install the firmware
+if args.flash:
+  print "Checking for installation pre-requisites..."
+  for i in installPrereqs:
+    p = subprocess.Popen(['/usr/bin/env', 'which', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    p.communicate()
+    if p.returncode > 0:
+      if not args.flash:
+        sys.stdout.write("Unable to find %s, but performing DRY RUN, so will not be installed.  Stopping.\n" % i)
+        exit(2)
+      else:
+        sys.stdout.write("Unable to find %s.  Installing..." % i)
+        sys.stdout.flush()
+        p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        p.communicate()
+        if p.returncode > 0:
+          print "Failed.  Do the needful." 
+          exit(1)
+        else:
+          print "Success!"
+
+# Generate JSON firmware report
+if args.report:
+  sysCurrent = True
+  report = {}
+  servernum = re.findall('\d{6}(?=-)', os.uname()[1])[0]
+  report[servernum] = {}
+  for part in firmwares[sysType]:
+    verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+    (version, stderr) = verProc.communicate()
+    if verProc.returncode == 0 and version:
+      report[servernum][part] = {
+        "Installed" : version.strip(),
+        "Available" : firmwares[sysType][part]["ver"]
+      }
+      if firmwares[sysType][part]["ver"] not in version.strip():
+        sysCurrent = False
+    else:
+      if verProc.returncode != 0 or not version:
+        print "Detection Failed for {}! {}" .format(part, stderr)
+        print "Try running the check manually:\n{}" .format(firmwares[sysType][part]["check"])
+        exit(5)
+  report[servernum]["Current"] = sysCurrent
+  print "{}" .format(json.dumps(report))
+
+# Check existing firmware version and install if necessary
+needsUpdate = False
+if not args.report:
+  for part in firmwares[sysType]:
+    if part not in args.do:
+      continue
+
+    sys.stdout.write("\n")
+    sys.stdout.write("Verifying current %s version: " % part)
+    sys.stdout.flush()
+    verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+    (version, stderr) = verProc.communicate()
+
+    if verProc.returncode == 0 and firmwares[sysType][part]["ver"] in version.strip():
+      print "Already current. Nothing to do."
+    else:
+      if verProc.returncode != 0:
+        print "Detection Failed! %s" % stderr
+        exit(5)
+      else:
+        needsUpdate = True
+        sys.stdout.write("Needs update (%s -> %s)\n" % (version.strip(), firmwares[sysType][part]["ver"]))
+        sys.stdout.flush()
+
+        if args.flash:
+          # Download the firmwares
+          url = "%s%s" % (baseUrl, firmwares[sysType][part]["fwpkg"])
+
+          sys.stdout.write("Downloading %s" % firmwares[sysType][part]["fwpkg"])
+          sys.stdout.flush()
+          try:
+            r = requests.get(url)
+          except:
+            print "Failed!  Aborting."
+            exit(3)
+
+          try:
+            with open("./%s" % firmwares[sysType][part]["fwpkg"], "wb") as pkg:
+              pkg.write(r.content)
+          except IOError:
+            print "Unable to write file %s.  Aborting." % firmwares[sysType][part]["fwpkg"]
+            exit(4)
+          else:
+            print " -> Success!"
+
+          # Check MD5Sum
+          sys.stdout.write("Checking MD5: ")
+          sys.stdout.flush()
+
+          md5sumCmd = "/usr/bin/env md5sum %s" % firmwares[sysType][part]["fwpkg"]
+          p = subprocess.Popen(md5sumCmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+          (md5, err) = p.communicate()
+
+          if md5.split(" ")[0] == firmwares[sysType][part]["md5"]:
+            print "Match!"
+          else:
+            print "Mismatch!  Report this immediately to aaron.segura@rackspace.com."
+            exit(66)
+
+          sys.stdout.write("Extracting firmware: " )
+          sys.stdout.flush()
+
+          try:
+            os.mkdir("%s/%s" % (workDir, part))
+          except:
+            pass
+
+          try:
+            os.chdir("%s/%s" % (workDir, part))
+          except:
+            print "Unable to chdir %s/%s.  Aborting." % (workDir, part)
+            continue
+
+          extractCmd  = "rpm2cpio %s/%s | cpio -id" % (workDir,firmwares[sysType][part]["fwpkg"])
+          extractProc = subprocess.Popen(extractCmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+          (stdout, stderr) = extractProc.communicate()
+
+          if extractProc.returncode != 0:
+            print "Failed! %s" % stderr
+          else:
+            print "Success!"
+            sys.stdout.write("Flashing...")
+            sys.stdout.flush()
+
+            dirCmd = "dirname %s/%s/usr/lib/*/hp-firmware-*/hpsetup" % (workDir, part)
+            dirProc = subprocess.Popen(dirCmd, stdout=PIPE, shell=True)
+            (flashDir, stderr) = dirProc.communicate()
+
+            try:
+              os.chdir(flashDir.strip())
+            except OSError, err:
+              print "Failed - cannot chdir to \"%s\", %s" % (flashDir.strip(), err.strerror)
+
+            flashProc = subprocess.Popen(["/usr/bin/env", "bash", "./hpsetup"], stdout=PIPE, stderr=PIPE, stdin=PIPE)
+            (stdout, stderr) = flashProc.communicate(firmwares[sysType][part]["inp"])
+            if flashProc.returncode == firmwares[sysType][part]["ret"]:
+              print "Success!"
+            else:
+              print "Failed!"
+
+            print "Writing log to %s/%s.log" % (workDir, part)
+
+            with open("%s/%s.log" % (workDir, part), "w+") as fp:
+              fp.write(stdout)
+              fp.write(stderr)
+
+            os.chdir(workDir)
+
+  print ""
+
+if not args.flash and not args.report:
+  if needsUpdate:
+    print "SUMMARY: Needs Update"
+    ret = 1
+  else:
+    print "SUMMARY: System up-to-date"
+    ret = 0
+
+exit(ret)

--- a/tasks/hp_firmware_updater.yml
+++ b/tasks/hp_firmware_updater.yml
@@ -1,0 +1,79 @@
+---
+# Copyright 2017-Present, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add HP SDR Repo keys
+  apt_key:
+    url: "{{ item.url }}"
+    state: "{{ item.state }}"
+  with_items: "{{ ops_hp_tools_apt_repo_keys }}"
+  register: add_keys
+  until: add_keys|success
+  ignore_errors: True
+  retries: 5
+  delay: 2
+
+- name: Add HP MCP Tool repo
+  apt_repository:
+    repo: "{{ item.repo }}"
+    state: "{{ item.state }}"
+    filename: "{{ item.filename | default(omit) }}"
+  with_items: "{{ ops_hp_tools_apt_repos }}"
+  register: add_repos
+  until: add_repos|success
+  retries: 5
+  delay: 2
+
+- name: Update apt if necessary
+  apt:
+    update_cache: yes
+    cache_valid_time: 600
+  when: add_repos|changed
+
+- name: Install HP firmware update dependencies
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ ops_hp_tools_apt_firmware_packages }}"
+  register: install_packages
+  until: install_packages|success
+  retries: 5
+  delay: 2
+
+- name: Copy HP firmware update script to hosts
+  copy:
+    src: files/update_hp_firmware.py
+    dest: /usr/local/bin/update_hp_firmware.py
+    mode: 0755
+
+- name: Check if screen is installed
+  find:
+    paths: "/usr/bin,/bin/,/usr/local/bin"
+    patterns: "screen"
+  register: screen_binary
+
+- name: Check for concurrent update_hp_firmware.py execution
+  shell: |
+    ps a |grep update_hp_firmware.py |grep -v grep
+  ignore_errors: True
+  register: update_hp_firmware_running
+
+- name: Execute HP firmware upgrade inside background
+  shell: |
+    {{ screen_binary.files.0.path }} -d -m -L -t "hp_firmware_update" /usr/local/bin/update_hp_firmware.py -f
+  when:
+    - screen_binary.matched > 0
+    - install_packages|success
+    - update_hp_firmware_running.rc == 1
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -168,3 +168,10 @@
     - inventory_hostname in groups['hosts']
   tags:
     - support_packages
+
+- include: hp_firmware_updater.yml
+  when:
+    - inventory_hostname in groups['hosts']
+    - ops_update_hp_firmware | bool == true
+  tags:
+    - hp_firmware_updater

--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -18,3 +18,6 @@ ops_aacraid_apt_repos:
 
 ops_hwraid_apt_repos:
   - { repo: "deb {{ ops_hwraid_apt_repo_url }} {{ ansible_lsb.codename }} main", state: "present" }
+
+ops_hp_tools_apt_repos:
+  - { repo: "deb {{ ops_hp_tools_apt_repo_url }} {{ ansible_lsb.codename }} main", state: "present" }

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -18,3 +18,6 @@ ops_aacraid_apt_repos:
 
 ops_hwraid_apt_repos:
   - { repo: "deb {{ ops_hwraid_apt_repo_url }} wily main", state: "present" }
+
+ops_hp_tools_apt_repos:
+  - { repo: "deb {{ ops_hp_tools_apt_repo_url }} {{ ansible_lsb.codename }} main", state: "present" }


### PR DESCRIPTION
The existing scripted HP firmware updates
are now part of the openstack-ops module.
The rollout and automation is limited to HP
servers when the conditional ops_update_hp_firmware
is set to true