### PR TITLE
Added the ability to update Intel 10G NICs

### DIFF
--- a/files/update_hp_firmware.py
+++ b/files/update_hp_firmware.py
@@ -15,7 +15,7 @@ from subprocess import PIPE
 
 VERSION = '2017-05-31'
 
-checkPrereqs    = ["dmidecode", "ethtool", "hpssacli", "hponcfg"]
+checkPrereqs    = ["dmidecode", "ethtool", "hpssacli", "hponcfg", "lspci", "systool"]
 installPrereqs  = ["rpm2cpio"]
 
 baseUrl = "http://aaronsegura.com/hpfw/"
@@ -30,11 +30,12 @@ parser.add_argument("--NIC", help="Flash NIC firmware", dest="do", action="appen
 parser.add_argument("--SYS", help="Flash System BIOS", dest="do", action="append_const", const="SYSTEM")
 parser.add_argument("--RAID", help="Flash RAID Controller", dest="do", action="append_const", const="RAID")
 parser.add_argument("--ILO", help="Flash ILO Controller", dest="do", action="append_const", const="ILO")
+parser.add_argument("--INIC", help="Flash Intel NIC firmware", dest="do", action="append_const", const="INIC")
 
 args = parser.parse_args()
 
 if args.do == None:
-  args.do = ["NIC", "SYSTEM", "RAID", "ILO"]
+  args.do = ["NIC", "SYSTEM", "RAID", "ILO", "INIC"]
 
 if not args.flash and not args.install and not args.report:
   print ""
@@ -100,6 +101,23 @@ firmwares["ProLiant DL380 Gen9"] = {
     "md5"   : "a2fd504e1f77333f38ba5bbdbdeec36a",
     "inp"   : "A\n",
     "ret"   : 1
+  },
+  "INIC": {
+    "ver"   : {
+        "560FLB"      : "800008C7",
+        "560FLR-SFP+" : "80000838",
+        "560SFP+"     : "80000835",
+        "560M"        : "8000083D",
+        "561FLR-T"    : "800005B6",
+        "561T"        : "800005D3",
+        "562i"        : "800006FC",
+        "562FLR-SFP+" : "800029F7",
+        "562SFP+"     : "800029F6",
+        "563i"        : "80002B0E"
+    },
+    "fwpkg" : "hp-firmware-nic-intel-1.11.13-1.1.x86_64.rpm",
+    "md5"   : "541db2f190e3741df626e24db1c1bf61",
+    "ret"   : 1
   }
 }
 
@@ -116,10 +134,16 @@ for i in checkPrereqs:
     else:
       sys.stdout.write("Unable to find %s.  Installing..." % i)
       sys.stdout.flush()
-      p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+      if i == "systool":
+        package = "sysfsutils"
+      elif i == "lspci":
+        package = "pciutils"
+      else:
+        package = i
+      p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', package], stdin=PIPE, stdout=PIPE, stderr=PIPE)
       p.communicate()
       if p.returncode > 0:
-        print "Failed.  Do the needful." 
+        print "Failed.  Do the needful."
         exit(1)
       else:
         print "Success!"
@@ -152,10 +176,68 @@ if args.flash:
         p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
         p.communicate()
         if p.returncode > 0:
-          print "Failed.  Do the needful." 
+          print "Failed.  Do the needful."
           exit(1)
         else:
           print "Success!"
+
+if "INIC" in args.do:
+  #Verifying the presence of 10G Intel NICs.
+  inics = {}
+  s = subprocess.Popen(['/usr/bin/env', 'lspci', '-v', '-d', '8086:1528'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+  out = s.communicate()[0].strip()
+  if 'Intel Corporation Ethernet Controller 10-Gigabit X540-AT2' in out:
+    for x in re.split('\n\n', out):
+      bye = False
+      slot = None
+      model = None
+      names = []
+      nvm = None
+      slot = x[0:5]
+      try:
+        model = re.search('56[0-3][A-Z,i]{1,3}-?[A-Z]{0,3}\+?', x).group(0)
+      except IndexError:
+        print "Could not find the model number for the nic in slot {}." .format(slot)
+        bye = True
+      if model:
+        n = subprocess.Popen(['/usr/bin/env', 'systool', '-c', 'net'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        systout = n.communicate()[0].strip().splitlines()
+        for i, line in enumerate(systout):
+          if slot in line:
+            try:
+              names.append(re.search('(?<=Class Device\s=\s\")[e,p][n,m,t,0-9][o,s,h,p]?[0-9]f?[0-9]?', systout[i-1]).group(0))
+            except IndexError:
+              print "Could not find the NIC names for the {} in slot: {}" .format(model, slot)
+              bye = True
+        if names:
+          inics[slot] = {}
+          f = subprocess.Popen(['/usr/bin/env', 'ethtool', '-i', '{}' .format(names[0])], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+          warez = f.communicate()[0].strip().upper().splitlines()
+          for line in warez:
+            if 'FIRMWARE-VERSION:' in line:
+              try:
+                nvm = re.search('(?<=FIRMWARE-VERSION:\s0X)[A-F,0-9]{8}', line).group(0)
+                inics[slot]['Names'] = names
+                inics[slot]['Model'] = model
+                inics[slot]['NVM']   = nvm
+              except IndexError:
+                print 'Could not find the firmware version.'
+                print 'Check "ethtool -i" output for NIC: {}' .format(names[0])
+                bye = True
+              except KeyError:
+                print "Hit KeyError setting inic values"
+                exit(1)
+
+    if bye:
+      print "Look into the NIC info errors above before attempting to flash the Intel 10Gb NICs."
+      exit(1)
+    else:
+      inicinp = '\n\n' * len(inics)
+      firmwares[sysType]["INIC"]["inp"] = inicinp
+  else:
+    print "No Intel 10Gb NICs to flash, skipping..."
+    args.do.remove('INIC')
+
 
 # Generate JSON firmware report
 if args.report:
@@ -164,48 +246,73 @@ if args.report:
   servernum = re.findall('\d{6}(?=-)', os.uname()[1])[0]
   report[servernum] = {}
   for part in firmwares[sysType]:
-    verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
-    (version, stderr) = verProc.communicate()
-    if verProc.returncode == 0 and version:
-      report[servernum][part] = {
-        "Installed" : version.strip(),
-        "Available" : firmwares[sysType][part]["ver"]
-      }
-      if firmwares[sysType][part]["ver"] not in version.strip():
-        sysCurrent = False
-    else:
-      if verProc.returncode != 0 or not version:
-        print "Detection Failed for {}! {}" .format(part, stderr)
-        print "Try running the check manually:\n{}" .format(firmwares[sysType][part]["check"])
-        exit(5)
+    if not part == 'INIC':
+      verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+      (version, stderr) = verProc.communicate()
+      if verProc.returncode == 0 and version:
+        report[servernum][part] = {
+          "Installed" : version.strip(),
+          "Available" : firmwares[sysType][part]["ver"]
+        }
+        if firmwares[sysType][part]["ver"] not in version.strip():
+          sysCurrent = False
+      else:
+        if verProc.returncode != 0 or not version:
+          print "Detection Failed for {}! {}" .format(part, stderr)
+          print "Try running the check manually:\n{}" .format(firmwares[sysType][part]["check"])
+          exit(5)
+    elif part == 'INIC':
+      report[servernum][part] = {}
+      report[servernum][part]['Cards'] = []
+      for nic in inics:
+        report[servernum][part]['Cards'].append({
+          "Model": inics[nic]['Model'],
+          "Names": inics[nic]['Names'],
+          "Installed": inics[nic]['NVM'],
+          "Available": firmwares[sysType]["INIC"]["ver"][inics[nic]['Model']]
+        })
+        if inics[nic]['NVM'] != firmwares[sysType]["INIC"]["ver"][inics[nic]['Model']]:
+          sysCurrent = False
   report[servernum]["Current"] = sysCurrent
   print "{}" .format(json.dumps(report))
 
 # Check existing firmware version and install if necessary
 needsUpdate = False
 if not args.report:
-  for part in firmwares[sysType]:
-    if part not in args.do:
-      continue
+  for part in args.do:
+    partUpdate = False
+    if not part == 'INIC':
 
-    sys.stdout.write("\n")
-    sys.stdout.write("Verifying current %s version: " % part)
-    sys.stdout.flush()
-    verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
-    (version, stderr) = verProc.communicate()
+      sys.stdout.write("\n")
+      sys.stdout.write("Verifying current %s version: " % part)
+      sys.stdout.flush()
+      verProc = subprocess.Popen(firmwares[sysType][part]["check"], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+      (version, stderr) = verProc.communicate()
 
-    if verProc.returncode == 0 and firmwares[sysType][part]["ver"] in version.strip():
-      print "Already current. Nothing to do."
-    else:
-      if verProc.returncode != 0:
-        print "Detection Failed! %s" % stderr
-        exit(5)
+      if verProc.returncode == 0 and firmwares[sysType][part]["ver"] in version.strip():
+        print "Already current. Nothing to do."
       else:
-        needsUpdate = True
-        sys.stdout.write("Needs update (%s -> %s)\n" % (version.strip(), firmwares[sysType][part]["ver"]))
-        sys.stdout.flush()
+        if verProc.returncode != 0:
+          print "Detection Failed! %s" % stderr
+          exit(5)
+        else:
+          needsUpdate = True
+          partUpdate  = True
+          sys.stdout.write("Needs update (%s -> %s)\n" % (version.strip(), firmwares[sysType][part]["ver"]))
+          sys.stdout.flush()
 
-        if args.flash:
+    elif part == 'INIC':
+      print
+      print "Verifying current Intel 10G NIC Versions: "
+      for nic in inics:
+        if inics[nic]['NVM'] == firmwares[sysType]["INIC"]["ver"][inics[nic]['Model']]:
+          print " {} already current. Nothing to do." .format(inics[nic]['Names'])
+        else:
+          needsUpdate = True
+          partUpdate = True
+          print " {} needs update ({} -> {})" .format(inics[nic]['Names'], inics[nic]['NVM'], firmwares[sysType]["INIC"]["ver"][inics[nic]['Model']])
+
+    if args.flash and partUpdate:
           # Download the firmwares
           url = "%s%s" % (baseUrl, firmwares[sysType][part]["fwpkg"])
 

--- a/files/update_hp_firmware.py
+++ b/files/update_hp_firmware.py
@@ -15,8 +15,18 @@ from subprocess import PIPE
 
 VERSION = '2017-05-31'
 
-checkPrereqs    = ["dmidecode", "ethtool", "hpssacli", "hponcfg", "lspci", "systool"]
-installPrereqs  = ["rpm2cpio"]
+# Command to package name mappings
+checkPrereqs    = {
+  "dmidecode": "dmidecode",
+  "ethtool":   "ethtool",
+  "hpssacli":  "hpssacli",
+  "hponcfg":   "hponcfg",
+  "lspci":     "pciutils",
+  "systool":   "sysfsutils"
+  }
+installPrereqs  = {
+  "rpm2cpio": "rpm2cpio"
+  }
 
 baseUrl = "http://aaronsegura.com/hpfw/"
 workDir = "%s/%s-%s" % (os.environ["HOME"], "hpfw-upgrade", dt.datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))
@@ -134,13 +144,7 @@ for i in checkPrereqs:
     else:
       sys.stdout.write("Unable to find %s.  Installing..." % i)
       sys.stdout.flush()
-      if i == "systool":
-        package = "sysfsutils"
-      elif i == "lspci":
-        package = "pciutils"
-      else:
-        package = i
-      p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', package], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+      p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', checkPrereqs[i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
       p.communicate()
       if p.returncode > 0:
         print "Failed.  Do the needful."
@@ -173,7 +177,7 @@ if args.flash:
       else:
         sys.stdout.write("Unable to find %s.  Installing..." % i)
         sys.stdout.flush()
-        p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        p = subprocess.Popen(['/usr/bin/env', 'apt-get', 'install', '-y', installPrereqs[i], stdin=PIPE, stdout=PIPE, stderr=PIPE)
         p.communicate()
         if p.returncode > 0:
           print "Failed.  Do the needful."
@@ -205,7 +209,7 @@ if "INIC" in args.do:
         for i, line in enumerate(systout):
           if slot in line:
             try:
-              names.append(re.search('(?<=Class Device\s=\s\")[e,p][n,m,t,0-9][o,s,h,p]?[0-9]f?[0-9]?', systout[i-1]).group(0))
+              names.append(re.search('(?<=Class Device\s=\s\")([^\"]|\\\")*, systout[i-1]).group(0))
             except IndexError:
               print "Could not find the NIC names for the {} in slot: {}" .format(model, slot)
               bye = True


### PR DESCRIPTION
Now has the ability to update Intel 10G NIC EEPROM & ROM via the "INIC" option, included by default when no option is specified.

The data gathering requires two new utilities, systool and lspci.

Because each Intel 10G card model has a different EEPROM/NVM version hex, and because there are systems with more than one card model, implemented a separate check for the INIC part flag.

Broadcom NICs are still updated separately via the NIC part flag.