### PR TITLE
Adding control plane archival, swift deletion and hp firmware playbooks

### DIFF
--- a/playbooks/archive-control-plane.yml
+++ b/playbooks/archive-control-plane.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Archive container(s)
+  hosts: "{{ container_group|default('all_containers') }}"
+  gather_facts: false
+  serial: '20%'
+  user: root
+  pre_tasks:
+    - name: Create container archive directory
+      file:
+        path: /opt/archives
+        state: directory
+      delegate_to: "{{ physical_host }}"
+
+    - name: Collect container configuration
+      shell: find . -type f -iname \*\.ini -o -iname \*\.sh -o -iname config
+      args:
+        chdir: "/var/lib/lxc/{{ item }}"
+      with_items: "{{ inventory_hostname }}"
+      register: container_config
+      delegate_to: "{{ physical_host }}"
+  tasks:
+    - name: Get container current state
+      shell: "lxc-info -sn {{ inventory_hostname }} | awk '{print $2}'"
+      register: current_state
+      delegate_to: "{{ physical_host }}"
+
+    - name: Archive container rootfs
+      lxc_container:
+        name: "{{ rpc_release }}-{{ inventory_hostname }}"
+        state: "{{ container_state[current_state.stdout.strip()] }}"
+        archive: true
+        archive_path: /opt/archives
+      delegate_to: "{{ physical_host }}"
+
+    - name: Archive container configuration
+      shell: "tar czf /opt/archives/{{ rpc_release }}-{{ inventory_hostname }}_config.tgz {{ container_config.results[0].stdout |replace('\n', ' ') }}"
+      args:
+        chdir: "/var/lib/lxc/{{ item }}"
+      with_items: "{{ inventory_hostname }}"
+      delegate_to: "{{ physical_host }}"
+
+  vars:
+    container_state:
+      RUNNING: started
+      STOPPED: stopped
+      FROZEN: frozen

--- a/playbooks/hp-firmware-update.yml
+++ b/playbooks/hp-firmware-update.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: Run HP firmware update
+  hosts: hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  tasks:
+    - include_vars: "../defaults/main.yml"
+    - include: "../tasks/hp_firmware_updater.yml"
+      when:
+        - ansible_system_vendor.split()[0] | lower == 'hp'
+  vars:
+    hp_firmware_updater: true

--- a/playbooks/swift-datacrusher.yml
+++ b/playbooks/swift-datacrusher.yml
@@ -21,8 +21,11 @@
 # Options can be overridden with passing these arguments to openstack-ansible:
 # openstack-ansible swift-datacrusher.yml -e xfs_inode_size=256 -e xfs_format_options='-linternal' -e exclude_drive_labels="disk1,disk2" -e exclude_drive_labels_format_option="disk3,disk4"
 
-- name: Please remove me, I'm just a fail safe
-  please-remove-me-before-crushing-swift-and-you-know-what-you-are-doing:
+- hosts: all
+  vars_prompt:
+    - name: destroy_swift_data
+      prompt: "Do you really want to remove erase the swift cluster?"
+      default: False
 
 - name: Register mountpoints
   hosts: swift_obj
@@ -58,6 +61,7 @@
         - "swift-account-auditor"
         - "swift-container-sync"
         - "rsync"
+      when: destroy_swift_data |bool
       tags:
         - "service-stop"
         - "service-restart"
@@ -72,6 +76,7 @@
       when:
         - "{{ swift_drives.stdout_lines | length > 0 }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels | default ({}) ) }}"
+        - destroy_swift_data |bool
       tags:
         - "remount"
         - "umount"
@@ -86,6 +91,7 @@
         - "{{ swift_drives.stdout_lines | length > 0 }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels | default ({}) ) }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels_format_option | default ({}) ) }}"
+        - destroy_swift_data |bool
       tags: format-xfs
 
 - name: Format Swift disk excluded options
@@ -98,6 +104,7 @@
         - "{{ swift_drives.stdout_lines | length > 0 }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels | default ({}) ) }}"
         - "{{ item.split(',')[1] in ( exclude_drive_labels_format_option | default ({}) ) }}"
+        - destroy_swift_data |bool
       tags: format-xfs
 
 - name: Mount Swift disks
@@ -113,6 +120,7 @@
       when:
         - "{{ swift_drives.stdout_lines | length > 0 }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels | default ({}) ) }}"
+        - destroy_swift_data |bool
       tags:
         - "remount"
         - "mount"
@@ -129,6 +137,7 @@
       when:
         - "{{ swift_drives.stdout_lines | length > 0 }}"
         - "{{ item.split(',')[1] not in ( exclude_drive_labels | default ({}) ) }}"
+        - destroy_swift_data |bool
       tags: fix-permissions
 
 - name: Start Swift Services
@@ -154,6 +163,7 @@
         - "swift-account-auditor"
         - "swift-container-sync"
         - "rsync"
+      when: destroy_swift_data |bool
       tags:
         - "service-start"
         - "service-restart"


### PR DESCRIPTION
Adding control plane archival, swift deletion and hp firmware playbooks,
partly for stand alone deployment

(cherry picked from commit c15ebdf96b5ec03c81c5920423fca13571527589)