### PR TITLE
Limit HP server monitoring tools to 10.6 version

### DIFF
--- a/playbooks/install-hp-server-monitoring.yml
+++ b/playbooks/install-hp-server-monitoring.yml
@@ -23,6 +23,7 @@
         state: absent
       with_items:
         - downloads_linux_hpe_com_SDR_repo_mcp_ubuntu.list
+        - mcp.list
       ignore_errors: True
       when:
         - ansible_os_family == 'Debian'

--- a/playbooks/vars/hp-hardware-monitoring.yml
+++ b/playbooks/vars/hp-hardware-monitoring.yml
@@ -17,7 +17,7 @@
 # HP server utilities
 #
 ops_hp_tools_apt_repos:
-  - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/current non-free", state: "present" }
+  - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.60 non-free", state: "present" }
 
 ops_hp_tools_apt_repo_keys:
   - { url: "https://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub", state: "present" }
@@ -26,10 +26,10 @@ ops_hp_tools_apt_firmware_packages:
   - rpm2cpio
   - dmidecode
   - ethtool
-  - hpssacli
+  - ssacli
   - hp-health
   - hponcfg
 
 ops_hp_tools_monitoring_packages:
-  - hpssacli
+  - ssacli
   - hponcfg


### PR DESCRIPTION
The APT repos for the MCP and SDR HP repository is limited to version 10.6
instead of using current. This will allow other repos like rpc-maas to
synchronize with this repo and the resulting changes

Closes-Bug: #51