### PR TITLE
Include OSDs and MONs hosts groups into HP server monitoring

### DIFF
--- a/playbooks/install-hp-server-monitoring.yml
+++ b/playbooks/install-hp-server-monitoring.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Install HP server monitoring
-  hosts: hosts
+  hosts: hosts:osds:mons
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - name: Remove outdated MCP repo
@@ -24,6 +24,8 @@
       with_items:
         - downloads_linux_hpe_com_SDR_repo_mcp_ubuntu.list
         - mcp.list
+        - hp-mcp.list
+        - hp-stk.list
       ignore_errors: True
       when:
         - ansible_os_family == 'Debian'


### PR DESCRIPTION
The ceph standalone is using a separate ansible inventory
and the new host groups are included for the HP server
monitoring