### PR TITLE
Add insecure flag for neutron calls if necessary

### DIFF
--- a/playbooks/configure-neutron.yml
+++ b/playbooks/configure-neutron.yml
@@ -22,7 +22,7 @@
     - name: Check for rpc_support security group
       shell: |
         . /root/openrc
-        neutron security-group-list | /bin/grep -w "rpc-support"
+        neutron {{ openrc_insecure | bool | ternary('--insecure','') }} security-group-list | /bin/grep -w "rpc-support"
       register: rpc_support_sec_group
       changed_when: false
       failed_when: rpc_support_sec_group.rc not in [0, 1]
@@ -30,7 +30,7 @@
     - name: Create rpc_support security group
       shell: |
         . /root/openrc
-        neutron security-group-create rpc-support
+        neutron {{ openrc_insecure | bool | ternary('--insecure','') }} security-group-create rpc-support
       register: sec_group_create
       changed_when: sec_group_create.rc == 0
       failed_when: sec_group_create.rc != 0
@@ -39,12 +39,13 @@
     - name: Create rpc_support security group rules ports
       shell: |
         . /root/openrc
-        neutron security-group-rule-create --direction ingress \
-                                           --protocol tcp \
-                                           --port-range-min {{ item }} \
-                                           --port-range-max {{ item }} \
-                                           --remote-ip-prefix 0.0.0.0/0 \
-                                           rpc-support
+        neutron {{ openrc_insecure | bool | ternary('--insecure','') }} security-group-rule-create \
+                --direction ingress \
+                --protocol tcp \
+                --port-range-min {{ item }} \
+                --port-range-max {{ item }} \
+                --remote-ip-prefix 0.0.0.0/0 \
+                rpc-support
 
       register: sec_group_rules_ports
       changed_when: sec_group_rules_ports.rc == 0
@@ -56,10 +57,11 @@
     - name: Create rpc_support security group rules icmp
       shell: |
         . /root/openrc
-        neutron security-group-rule-create --direction ingress \
-                                           --protocol icmp \
-                                           --remote-ip-prefix 0.0.0.0/0 \
-                                           rpc-support
+        neutron {{ openrc_insecure | bool | ternary('--insecure','') }} security-group-rule-create \
+                 --direction ingress \
+                 --protocol icmp \
+                 --remote-ip-prefix 0.0.0.0/0 \
+                 rpc-support
       register: sec_group_rules_icmp
       changed_when: sec_group_rules_icmp.rc == 0
       when: sec_group_create|changed

--- a/playbooks/support-key.yml
+++ b/playbooks/support-key.yml
@@ -95,7 +95,7 @@
       register: local_support_key_check
 
 - name: Distribute RPC support key
-  hosts: os-infra_hosts[1:999]:utility_container
+  hosts: os-infra_hosts[1:999]:utility_container:neutron_agents_container
   gather_facts: "false"
   tasks:
     - name: Distribute support SSH key for cluster operations


### PR DESCRIPTION
The neutron commands are prefixed with insecure flags in case openrc_insecure is set to true