### PR TITLE
Distribute support key onto neutron agents

### DIFF
--- a/playbooks/support-key.yml
+++ b/playbooks/support-key.yml
@@ -84,7 +84,7 @@
     - "vars/main.yml"
 
 - name: Get local RPC support pubkey hash
-  hosts: os-infra_hosts:utility_container
+  hosts: os-infra_hosts:utility_container:neutron_agents_container
   gather_facts: "false"
   tasks:
     - name: Retreive local support SSH key stats


### PR DESCRIPTION
The support key will be distributed to the neutron agents
in addition to the utilities and infra hosts