### PR TITLE
Allowing for meltdown overrides for HP updates

### DIFF
--- a/playbooks/update-hp-firmware.yml
+++ b/playbooks/update-hp-firmware.yml
@@ -49,7 +49,7 @@
 
     - name: Execute HP firmware upgrade as background task
       command: |
-        {{ screen_binary.stdout }} -d -m -L -t "hp_firmware_update" bash -c "source {{ ops_pip_venv_enabled | bool | ternary(ops_venv + '/bin/activate', omit) }} || true; /usr/local/bin/update_hp_firmware.py -f"
+        {{ screen_binary.stdout }} -d -m -L -t "hp_firmware_update" bash -c "source {{ ops_pip_venv_enabled | bool | ternary(ops_venv + '/bin/activate', omit) }} || true; /usr/local/bin/update_hp_firmware.py -f {{ firmware_use_meltdown | default(false) | bool | ternary('--meltdown', '') }}"
       changed_when: false
       when:
         - screen_binary |changed


### PR DESCRIPTION
A new options --meltdown is added to allow
users to either deploy a pre meltdown or a meltdown
mitigated firmware. By default, a pre meltdown
firmware is installed for the update_hp_firmware.py script.

When using the playbook, the override firmware_use_meltdown
can be enabled to trigger the firmware update using
the lates firmware