### PR TITLE
RI-438 Install PIP and Vim

### DIFF
--- a/playbooks/configure-bash-environment.yml
+++ b/playbooks/configure-bash-environment.yml
@@ -56,11 +56,12 @@
       when: ansible_os_family == 'Debian'
 
     - name: Set vim.basic as default
-      command: update-alternatives --set editor /usr/bin/vim.basic
+      command: "update-alternatives --set editor /usr/bin/vim.basic"
       when:
         - editor.rc != 0
         - not editor.stdout|search('vim')
         - ansible_os_family == 'Debian'
+        - ansible_virtualization_role == 'host:utility_all'
 
     - name: Disable motd for ssh
       lineinfile:

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -30,6 +30,7 @@ ops_apt_util_packages:
   - iptables-persistent
   - lsof
   - openssh-server
+  - python-pip
   - sudo
   - tcpdump
   - vim
@@ -65,4 +66,3 @@ ops_host_kernel_sysctl:
   - { key: 'net.ipv4.ip_forward', value: 1 }
   - { key: 'net.ipv4.conf.all.rp_filter', value: 0 }
   - { key: 'net.ipv4.conf.default.rp_filter', value: 0 }
-


### PR DESCRIPTION
Upstream has removed the installation of PIP install on
hosts/containers. This installs PIP and VIM.