### PR TITLE
Replace no longer maintaned mysql-python

### DIFF
--- a/playbooks/install-holland-db-backup.yml
+++ b/playbooks/install-holland-db-backup.yml
@@ -66,8 +66,10 @@
     - name: Install pip dependencies required by holland
       pip:
         name: "{{ item }}"
-        virtualenv: "{{ ops_holland_venv_enabled | bool | ternary(ops_holland_venv, omit) }}"
-        extra_args: "{{ ops_pip_install_options | default('') }}"
+        virtualenv: "{{ ops_holland_venv }}"
+        extra_args: >-
+          {{ pip_install_options|default('') }}
+          --isolated
       with_items: "{{ ops_holland_pip_dependencies | default([]) }}"
       register: pip_install
       until: pip_install | success
@@ -86,7 +88,7 @@
     - name: Install holland program
       pip:
         name: "/opt/{{ ops_holland_service_name }}_{{ ops_holland_git_install_branch | replace('/', '_') }}"
-        virtualenv: "{{ ops_holland_venv_enabled | bool | ternary(ops_holland_venv, omit) }}"
+        virtualenv: "{{ ops_holland_venv }}"
         extra_args: "{{ pip_install_options|default('') }}"
       register: pip_install
       until: pip_install | success
@@ -98,8 +100,8 @@
     - name: Install holland pip repo plugins
       pip:
         name: "{{ ops_holland_git_dest }}/{{ item.path }}/{{ item.package }}"
+        virtualenv: "{{ ops_holland_venv }}"
         extra_args: "{{ pip_install_options|default('') }}"
-        virtualenv: "{{ ops_holland_venv_enabled | bool | ternary(ops_holland_venv, omit) }}"
       when: ops_holland_git_dest is defined and ops_holland_git_repo_plugins is defined
       with_items: "{{ ops_holland_git_repo_plugins }}"
       register: pip_install
@@ -156,7 +158,7 @@
         minute: "{{ (ansible_eth0['ipv4']['address']|replace('.', '')|int)%60}}"
         hour: 23
         state: present
-        job: "{{ ops_holland_venv_enabled | bool | ternary(ops_holland_venv_bin + '/python2.7', '') }} {{ ops_holland_venv_enabled | bool | ternary(ops_holland_venv_bin + '/', '/usr/local/bin/') }}holland bk"
+        job: "{{ ops_holland_venv_bin }}/python2.7 {{ ops_holland_venv_bin }}/holland bk"
         user: root
         cron_file: holland_backups
       tags:
@@ -179,21 +181,14 @@
       changed_when: found_holland_backups.rc != 0
       register: found_holland_backups
 
-    - name: Create holland backup (venv)
+    - name: Create holland backup
       command: |
-        {{ ops_holland_venv_bin + '/' }}holland bk
+        {{ ops_holland_venv_bin }}/holland bk
       when:
-        - ops_holland_venv_enabled | bool
         - found_holland_backups | changed
       tags:
         - holland_create_backup
         - holland_all
-    - name: Create holland backup (no venv)
-      command: |
-        /usr/local/bin/holland bk
-      when:
-        - not ops_holland_venv_enabled | bool
-        - found_holland_backups | changed
   tags:
     - holland_create_backup
     - holland_all

--- a/playbooks/templates/holland.conf.j2
+++ b/playbooks/templates/holland.conf.j2
@@ -17,7 +17,7 @@ umask = 0007
 
 # Define a path for holland and its spawned processes
 
-path = {% if ops_holland_venv_enabled | bool %}{{ ops_holland_venv_bin }}:{% endif %}/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+path = {{ ops_holland_venv_bin }}:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 
 [logging]
 ## where to write the log

--- a/playbooks/vars/holland.yml
+++ b/playbooks/vars/holland.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ops_holland_venv_enabled: True
 ops_holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
 ops_holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"
 
@@ -23,7 +22,7 @@ ops_holland_service_name: holland
 ops_holland_repo_path: "holland_{{ ops_holland_git_install_branch | replace('/', '_') }}"
 
 ops_holland_git_repo: https://github.com/holland-backup/holland
-ops_holland_git_install_branch: "v1.0.10"
+ops_holland_git_install_branch: "v1.1.8"
 ops_holland_git_dest: "/opt/{{ ops_holland_repo_path }}"
 # git_repo_plugins are other installable packages contained within the same git repo
 ops_holland_git_repo_plugins:
@@ -33,7 +32,7 @@ ops_holland_git_repo_plugins:
 
 ops_holland_pip_wheel_name: holland
 ops_holland_pip_dependencies:
-  - MySQL-python
+  - "mysqlclient<=1.3.13"
 
 ops_holland_packages:
   - git


### PR DESCRIPTION
In anticipation of a move to python3, the mysql-python dependency is
replaced with a newer, maintained, mysqlclient.
As the new package is available inside a OSA repo, holland will
be installed in a separate venv moving forward.
The alternative client, pymysql is not possible due to issue
https://github.com/PyMySQL/PyMySQL/issues/548

Holland is also updated to v1.1.8 with this change.

Closes-Bug: FLEEK-223